### PR TITLE
Feature/skip email from cre setup

### DIFF
--- a/src/app/setup/cre-registration-form/cre-registration-form.component.html
+++ b/src/app/setup/cre-registration-form/cre-registration-form.component.html
@@ -18,7 +18,8 @@
          class="alert alert-warning">
       {{ formErrors.email + ' ' + formErrors.password + ' ' + formErrors.confirmPassword + ' ' + message}}
     </div>
-    <div *ngIf="cloudProvider.isSelected === 2" class="mat-card-control-buttons">
+    <div class="mat-card-control-buttons"
+         *ngIf="cloudProvider.isSelected === 2 && (!_isSuccess || cloudProvider.name !== 'phenomenal')">
       <button mat-raised-button (click)="cloudProvider.isSelected=1;" color="accent">Back</button>
       <button mat-raised-button *ngIf="cloudProvider.name === 'phenomenal'" [disabled]="!form.valid" color="warn">
         Register

--- a/src/app/setup/cre-registration-form/cre-registration-form.component.html
+++ b/src/app/setup/cre-registration-form/cre-registration-form.component.html
@@ -1,11 +1,11 @@
 <div *ngIf="cloudProvider.isSelected === 2">
-  <p>Please register your Galaxy Administrator account</p>
+  <p>
+    Please choose the password for your Galaxy Administrator account<br>
+    (username: <em>{{ currentUser.email }}</em>)
+  </p>
+  <br>
 
   <form [formGroup]="form" (ngSubmit)="onSubmit()">
-    <mat-input-container class="input-width">
-      <input matInput [(ngModel)]="cloudProvider.credential.galaxy_admin_email"
-             placeholder="Galaxy Email" formControlName="email" required>
-    </mat-input-container>
     <mat-input-container class="input-width">
       <input matInput [(ngModel)]="cloudProvider.credential.galaxy_admin_password"
              placeholder="Galaxy Password" type="password" formControlName="password" required>
@@ -48,19 +48,21 @@
     <p>Username: <b>{{cloudProvider.credential.username}}</b></p>
     <p>Tenant Name: <b>{{cloudProvider.credential.tenant_name}}</b></p>
     <p>Auth URL: <b>{{cloudProvider.credential.url}}</b></p>
-    <p>Galaxy Email: <b>{{cloudProvider.credential.galaxy_admin_email}}</b></p>
+    <p>Galaxy Email: <b>{{currentUser.email}}</b></p>
   </div>
   <div *ngIf="cloudProvider.name === 'aws'">
     <p>Region: <b>{{cloudProvider.credential.default_region}}</b></p>
     <p>Access Key ID: <b>{{cloudProvider.credential.access_key_id}}</b></p>
-    <p>Galaxy Email: <b>{{cloudProvider.credential.galaxy_admin_email}}</b></p>
+    <p>Galaxy Email: <b>{{currentUser.email}}</b></p>
   </div>
   <div *ngIf="cloudProvider.name === 'gcp'">
     <p>Region: <b>{{cloudProvider.credential.default_region}}</b></p>
     <p>Project ID: <b>{{cloudProvider.credential.tenant_name}}</b></p>
-    <p>Galaxy Email: <b>{{cloudProvider.credential.galaxy_admin_email}}</b></p>
+    <p>Galaxy Email: <b>{{currentUser.email}}</b></p>
   </div>
-  <ng-template ngbModalContainer></ng-template>
+  <div class="mat-card-control-buttons">
+    <ng-template ngbModalContainer></ng-template>
+  </div>
   <ph-progress-bar-modal [credential]="cloudProvider.credential"
                          [cloudProvider]="cloudProvider"></ph-progress-bar-modal>
 </div>

--- a/src/app/setup/cre-registration-form/cre-registration-form.component.ts
+++ b/src/app/setup/cre-registration-form/cre-registration-form.component.ts
@@ -5,6 +5,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { emailValidator, matchingPasswords, passwordValidator } from '../validator';
 import { UserService } from "../../shared/service/user/user.service";
 import { AppConfig } from "../../app.config";
+import { User } from "../../shared/service/user/user";
 
 
 @Component({
@@ -18,7 +19,8 @@ export class CreRegistrationFormComponent implements OnInit {
   private _isFailed = false;
   _isSuccess = false;
   private _message = '';
-  passwordConfirm = "";
+  public currentUser: User;
+  passwordConfirm = '';
   form: FormGroup;
 
   formErrors = {
@@ -54,6 +56,14 @@ export class CreRegistrationFormComponent implements OnInit {
 
   ngOnInit() {
     this.buildForm();
+    this.userService.getObservableCurrentUser().subscribe(user => {
+      console.log("Updating the current user", user);
+      this.currentUser = <User> user;
+      if (user) {
+        console.log("*** Has Galaxy account: " + this.currentUser.hasGalaxyAccount);
+        console.log("Updated user @ CloudSetupEnvironment", user, this.currentUser)
+      }
+    });
   }
 
   get galaxyInstanceUrl() {
@@ -67,6 +77,7 @@ export class CreRegistrationFormComponent implements OnInit {
       'confirmPassword': ['', [Validators.required]]
     }, {validator: matchingPasswords('password', 'confirmPassword')});
 
+    this.currentUser = this.userService.getCurrentUser();
     this.form.valueChanges.subscribe(data => this.onValueChanged(data));
 
     this.onValueChanged(); // (re)set validation messages now

--- a/src/app/setup/cre-registration-form/cre-registration-form.component.ts
+++ b/src/app/setup/cre-registration-form/cre-registration-form.component.ts
@@ -110,23 +110,19 @@ export class CreRegistrationFormComponent implements OnInit {
 
   registerGalaxyAccount(username: string, email: string, password: string) {
 
-    let currentUser = this.userService.getCurrentUser();
     const newUsername = email.replace(/\W+/g, '-').toLowerCase();
     const user: GalaxyUser = {username: newUsername, password: password, email: email};
-
     try {
-      this.userService.createGalaxyAccount(currentUser.id, user).subscribe(
+      this.userService.createGalaxyAccount(this.currentUser.id, user).subscribe(
         data => {
-          console.log(data);
-
+          console.log("User data registered", data);
           if (data===null) {
             console.warn("Server response is empty");
             return this.processGalaxyAccountRegistrationFailure("No server response !!!");
           }
-
           this._isFailed = false;
           this._isSuccess = true;
-          currentUser.hasGalaxyAccount = true;
+          this.currentUser.hasGalaxyAccount = true;
           return false;
         },
         error => {
@@ -159,7 +155,7 @@ export class CreRegistrationFormComponent implements OnInit {
 
   onSubmit() {
     if (this.cloudProvider.name === 'phenomenal') {
-      this.registerGalaxyAccount('', this.form.value['email'], this.form.value['password']);
+      this.registerGalaxyAccount(this.currentUser.email, this.currentUser.email, this.form.value['password']);
     } else {
       this.cloudProvider.credential.galaxy_admin_email = this.form.value['email'];
       this.cloudProvider.credential.galaxy_admin_password = this.form.value['password'];

--- a/src/app/setup/cre-registration-form/cre-registration-form.component.ts
+++ b/src/app/setup/cre-registration-form/cre-registration-form.component.ts
@@ -63,7 +63,6 @@ export class CreRegistrationFormComponent implements OnInit {
   buildForm(): void {
 
     this.form = this.fb.group({
-      'email': ['', Validators.compose([Validators.required, emailValidator])],
       'password': ['', [Validators.required, Validators.minLength(8), passwordValidator]],
       'confirmPassword': ['', [Validators.required]]
     }, {validator: matchingPasswords('password', 'confirmPassword')});

--- a/src/app/setup/gcp-setup/gcp-setup.component.html
+++ b/src/app/setup/gcp-setup/gcp-setup.component.html
@@ -19,7 +19,7 @@
     {{ formErrors.region + ' ' + formErrors.accessKeyId + ' ' + formErrors.tenantName }}
   </div>
   <div class="mat-card-control-buttons">
-    <button mat-raised-button (click)="cloudProvider.isSelected=1;" color="accent">Back</button>
+    <button mat-raised-button (click)="cloudProvider.isSelected=0;" color="accent">Back</button>
     <button mat-raised-button [disabled]="!form.valid" color="primary">Next</button>
   </div>
 </form>


### PR DESCRIPTION
This PR simplifies the creation of a Galaxy account avoiding to ask for a new email and using the email of the already authenticated user 