### PR TITLE
Replace bullet icons on the 'Terms&Conditions' page

### DIFF
--- a/src/app/login/term-and-condition/term-and-condition.component.html
+++ b/src/app/login/term-and-condition/term-and-condition.component.html
@@ -8,11 +8,11 @@
       <div class="text-xs-left terms-list">
 
         <ul>
-          <li><i class="glyphicon glyphicon-chevron-right"></i>
+          <li><i class="fa fa-chevron-circle-right" aria-hidden="true"></i>
             I am fully aware of the <a href="http://phenomenal-h2020.eu/home/wp-content/uploads/2017/03/PhenoMeNal-ELSI-Terms-of-Use-1.pdf" target="_blank" style="font-weight: bold;">ELSI requirements</a>.</li>
-          <li><i class="glyphicon glyphicon-chevron-right"></i>
+          <li><i class="fa fa-chevron-circle-right" aria-hidden="true"></i>
             I will only use fully <a href="http://phenomenal-h2020.eu/home/help/login/elsi-diagrams/" target="_blank" style="font-weight: bold;">anonymised</a> data in any public PhenoMeNal CRE.</li>
-          <li><i class="glyphicon glyphicon-chevron-right"></i>
+          <li><i class="fa fa-chevron-circle-right" aria-hidden="true"></i>
             I accept the PhenoMeNal <a href="http://phenomenal-h2020.eu/home/wp-content/uploads/2017/03/Phenomenal-Terms-of-Use-version-1.0.pdf" target="_blank" style="font-weight: bold;">Terms and Conditions</a>.</li>
         </ul>
 


### PR DESCRIPTION
This PR replaces icon bullets not properly visualised on the Term&Conditions page by some browsers.