### PR TITLE
Change cursor on cloud selection boxes to a pointer

### DIFF
--- a/src/app/setup/provider-selector/provider-selector.component.html
+++ b/src/app/setup/provider-selector/provider-selector.component.html
@@ -11,7 +11,7 @@
 
     <div *ngFor="let cloudProvider of cloudProviderCollection; let i = index" [attr.data-index]="i">
 
-      <div [ngClass]="{'row': (i+1)%2 == 0 && !smallScreen, 'card-row': (i+1)%2 == 0 && !smallScreen }">
+      <div [ngClass]="{'row': (i+1)%2 == 0 && !smallScreen, 'card-row': (i+1)%2 == 0 && !smallScreen }" style="cursor: pointer;">
 
         <div [ngClass]="{'col-lg-6': true, 'card-size': true}">
           <mat-card (click)="selectCloudProvider(cloudProvider)">


### PR DESCRIPTION
During UX testing, when deploying a CRE it was not obvious that the cloud provider “boxes” (i.e., openstack, AWS, GCP) were clickable.  This PR changes the cursor when hovering over the boxes to a hand pointer.