### PR TITLE
Remove number of applications from App Library text

### DIFF
--- a/src/app/application-library/application-library.component.html
+++ b/src/app/application-library/application-library.component.html
@@ -4,7 +4,7 @@
       <div class="col-lg-12">
         <!--Panel-->
         <div class="card card-block">
-          <p class="card-text">App Library showcases our service catalogue listing {{appSize}} applications that are
+          <p class="card-text">App Library showcases our service catalogue listing of applications that are
             available via Galaxy workflows and Jupyter libraries through the Cloud Research Environment. For further
             information
             please click <a

--- a/src/app/application-library/application-library.component.ts
+++ b/src/app/application-library/application-library.component.ts
@@ -16,7 +16,6 @@ import { AppLibraryCategories } from "../shared/service/application-library/cate
 export class ApplicationLibraryComponent implements OnInit {
 
   apps;
-  appSize;
   content: string;
   isList = false;
   previousQuery: string;
@@ -59,7 +58,6 @@ export class ApplicationLibraryComponent implements OnInit {
       .subscribe(
         data => {
           this.apps = data;
-          this.appSize = data.length;
           this.setAppListFilter(false);
         }
       );


### PR DESCRIPTION
It only counts container, not tools, and it's not updated with queries